### PR TITLE
Update fetchRowsToSync.ts

### DIFF
--- a/src/databases/postgresql/fetchRowsToSync.ts
+++ b/src/databases/postgresql/fetchRowsToSync.ts
@@ -22,6 +22,7 @@ WHERE $[syncColumnName:name] = $[syncFlagTrue]
   return pg.any(sql, {
     tableName: schema.tableName,
     syncColumnName: schema.syncFlag.columnName,
-    syncFlagTrue: schema.syncFlag.true
+    syncFlagTrue: schema.syncFlag.true,
+    dbColumns
   })
 };

--- a/src/databases/postgresql/fetchRowsToSync.ts
+++ b/src/databases/postgresql/fetchRowsToSync.ts
@@ -14,9 +14,8 @@ export default (
   if (!dbColumns.includes(schema.idColumns.airtable)) {
     dbColumns.push(schema.idColumns.airtable);
   }
-  const preparedColumns: string[] = dbColumns.map(PGP.as.name);
   const sql: string = `
-SELECT ${preparedColumns.join(",")}
+SELECT $[dbColumns:name]
 FROM $[tableName:name]
 WHERE $[syncColumnName:name] = $[syncFlagTrue]
 `;


### PR DESCRIPTION
example of proper escaping for a list of column names.

read: https://github.com/vitaly-t/pg-promise#sql-names
